### PR TITLE
Fix USR1 signal ignored in timeout-1 mode

### DIFF
--- a/minui-presenter.c
+++ b/minui-presenter.c
@@ -417,11 +417,6 @@ void handle_input(struct AppState *state)
         }
     }
 
-    if (state->timeout_seconds < 0)
-    {
-        return;
-    }
-
     if (increment_item_list_index)
     {
         pthread_mutex_lock(&increment_item_list_index_lock);
@@ -448,6 +443,11 @@ void handle_input(struct AppState *state)
         {
             return;
         }
+    }
+
+    if (state->timeout_seconds < 0)
+    {
+        return;
     }
 
     PAD_poll();


### PR DESCRIPTION
### Issue

One of the usages for minui-presenter is to display progress from a shell script.
`--timeout -1` option is great for that option, but requires killing the presenter if another text is needed, which causes flickering during the restart.

If text pieces are static and pre-created ahead of time, they could be saved into a file - presenter already has a way to skip to the next messages if it received a USR1 signal.

Unfortunately, signal handling is not happening in `--timeout -1` mode.

### Change

Move `timeout_seconds` check after the `increment_item_list_index` case is handled.

### Tested

- Build locally (`PLATFORM=macos make`)
- Run presenter `./minui-presenter-macos --file messages.json --disable-auto-sleep --timeout -1`
- `kill -USR1 397410`
- Observe: presenter switches to the next line