### PR TITLE
feat: add i18n translation layer with NextUI minuisettings integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 minui
-/include
+/include/*
+!/include/i18n/
 /lib
 /platform
 minui-presenter-*

--- a/Makefile
+++ b/Makefile
@@ -40,13 +40,13 @@ PRODUCT = $(TARGET)
 # macOS-specific configuration
 ifeq ($(PLATFORM),macos)
   INCDIR = -I. -Iplatforms/macos/include/ -Iminui/workspace/all/common/ -Iplatforms/macos/platform/ -Iinclude/ $(SDL_CFLAGS)
-  SOURCE = $(TARGET).c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c platforms/macos/platform/platform.c include/parson/parson.c
+  SOURCE = $(TARGET).c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c platforms/macos/platform/platform.c include/parson/parson.c include/i18n/i18n.c
   CFLAGS = $(ARCH) -fomit-frame-pointer
   CFLAGS += $(INCDIR) -DPLATFORM=\"$(PLATFORM)\" -DUSE_$(SDL) -O3 -std=gnu99 -Wno-tautological-constant-out-of-range-compare -Wno-asm-operand-widths
   FLAGS = $(LIBS) $(SDL_LIBS) -lpthread -lm -lz
 else
   INCDIR = -I. -Iplatform/$(PLATFORM)/include/ -Iminui/workspace/all/common/ -Iminui/workspace/$(PLATFORM)/platform/ -Iinclude/
-  SOURCE = $(TARGET).c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c minui/workspace/$(PLATFORM)/platform/platform.c include/parson/parson.c
+  SOURCE = $(TARGET).c minui/workspace/all/common/scaler.c minui/workspace/all/common/utils.c minui/workspace/all/common/api.c minui/workspace/$(PLATFORM)/platform/platform.c include/parson/parson.c include/i18n/i18n.c
   FLAGS = -L$(LD_LIBRARY_PATH) -ldl -lmsettings $(LIBS) -l$(SDL) -l$(SDL)_image -l$(SDL)_ttf -lpthread -lm -lz
   # tg5050 uses NextUI toolchain which installs libmsettings to /opt/nextui
   ifeq ($(PLATFORM),tg5050)

--- a/include/i18n/i18n.c
+++ b/include/i18n/i18n.c
@@ -1,0 +1,174 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <ctype.h>
+
+#include "defines.h"  /* SDCARD_PATH, MAX_PATH */
+#include "i18n.h"
+
+#define I18N_BUCKETS    4096
+#define I18N_ARENA_SIZE (256 * 1024)
+#define I18N_LINE_MAX   1024
+
+typedef struct {
+    uint32_t    hash;
+    const char *key;
+    const char *value;
+} i18n_entry;
+
+static i18n_entry s_table[I18N_BUCKETS];
+static char       s_arena[I18N_ARENA_SIZE];
+static size_t     s_arena_used;
+static char       s_active_code[I18N_LANG_CODE_MAX];
+static int        s_inited;
+
+static uint32_t fnv1a(const char *s) {
+    uint32_t h = 0x811c9dc5u;
+    while (*s) {
+        h ^= (uint8_t)*s++;
+        h *= 0x01000193u;
+    }
+    return h;
+}
+
+static const char *arena_dup(const char *s, size_t len) {
+    if (s_arena_used + len + 1 > I18N_ARENA_SIZE) return NULL;
+    char *p = s_arena + s_arena_used;
+    memcpy(p, s, len);
+    p[len] = '\0';
+    s_arena_used += len + 1;
+    return p;
+}
+
+static void table_clear(void) {
+    memset(s_table, 0, sizeof(s_table));
+    s_arena_used = 0;
+}
+
+static int table_insert(const char *key, size_t klen, const char *val, size_t vlen) {
+    char keybuf[256];
+    if (klen >= sizeof(keybuf)) return 0;
+    memcpy(keybuf, key, klen);
+    keybuf[klen] = '\0';
+
+    uint32_t h = fnv1a(keybuf);
+    if (h == 0) h = 1;
+
+    size_t mask = I18N_BUCKETS - 1;
+    size_t i    = h & mask;
+    for (size_t probe = 0; probe < I18N_BUCKETS; ++probe) {
+        i18n_entry *e = &s_table[i];
+        if (e->hash == 0) {
+            const char *dk = arena_dup(key, klen);
+            const char *dv = arena_dup(val, vlen);
+            if (!dk || !dv) return 0;
+            e->hash  = h;
+            e->key   = dk;
+            e->value = dv;
+            return 1;
+        }
+        if (e->hash == h && strcmp(e->key, keybuf) == 0) {
+            const char *dv = arena_dup(val, vlen);
+            if (!dv) return 0;
+            e->value = dv;
+            return 1;
+        }
+        i = (i + 1) & mask;
+    }
+    return 0;
+}
+
+static void strip_trailing_ws(char *s, size_t *len) {
+    while (*len > 0 && (s[*len - 1] == ' ' || s[*len - 1] == '\t' ||
+                        s[*len - 1] == '\r' || s[*len - 1] == '\n')) {
+        s[--(*len)] = '\0';
+    }
+}
+
+static int parse_file(const char *path) {
+    FILE *f = fopen(path, "r");
+    if (!f) return 0;
+
+    char line[I18N_LINE_MAX];
+    while (fgets(line, sizeof(line), f)) {
+        char *p = line;
+        while (*p == ' ' || *p == '\t') ++p;
+        if (*p == '\0' || *p == '#' || *p == '\n' || *p == '\r') continue;
+
+        char *eq = strchr(p, '=');
+        if (!eq) continue;
+
+        size_t klen = (size_t)(eq - p);
+        while (klen > 0 && (p[klen - 1] == ' ' || p[klen - 1] == '\t')) --klen;
+        if (klen == 0) continue;
+
+        char *v = eq + 1;
+        while (*v == ' ' || *v == '\t') ++v;
+
+        size_t vlen = strlen(v);
+        strip_trailing_ws(v, &vlen);
+
+        table_insert(p, klen, v, vlen);
+    }
+    fclose(f);
+    return 1;
+}
+
+static int load_lang(const char *lang_code) {
+    table_clear();
+
+    char path[MAX_PATH];
+    snprintf(path, sizeof(path), "%s/en.lang", SDCARD_PATH I18N_LANG_DIR);
+    parse_file(path);
+
+    if (lang_code && *lang_code && strcmp(lang_code, "en") != 0) {
+        snprintf(path, sizeof(path), "%s/%s.lang",
+                 SDCARD_PATH I18N_LANG_DIR, lang_code);
+        parse_file(path);
+    }
+
+    strncpy(s_active_code, (lang_code && *lang_code) ? lang_code : "en",
+            sizeof(s_active_code) - 1);
+    s_active_code[sizeof(s_active_code) - 1] = '\0';
+    return 1;
+}
+
+void I18N_init(const char *lang_code) {
+    if (s_inited) return;
+    s_inited = 1;
+    load_lang(lang_code);
+}
+
+int I18N_reload(const char *lang_code) {
+    return load_lang(lang_code);
+}
+
+void I18N_quit(void) {
+    table_clear();
+    s_active_code[0] = '\0';
+    s_inited         = 0;
+}
+
+char *I18N_t(const char *key) {
+    static char empty[1] = { '\0' };
+    if (!key) return empty;
+    if (!s_inited) return (char *)key;
+
+    uint32_t h = fnv1a(key);
+    if (h == 0) h = 1;
+
+    size_t mask = I18N_BUCKETS - 1;
+    size_t i    = h & mask;
+    for (size_t probe = 0; probe < I18N_BUCKETS; ++probe) {
+        i18n_entry *e = &s_table[i];
+        if (e->hash == 0) return (char *)key;
+        if (e->hash == h && strcmp(e->key, key) == 0) return (char *)e->value;
+        i = (i + 1) & mask;
+    }
+    return (char *)key;
+}
+
+const char *I18N_active_code(void) {
+    return s_active_code[0] ? s_active_code : "en";
+}

--- a/include/i18n/i18n.h
+++ b/include/i18n/i18n.h
@@ -1,0 +1,23 @@
+#ifndef __I18N_H__
+#define __I18N_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define I18N_LANG_CODE_MAX 8
+#define I18N_LANG_DIR      "/.system/res/lang"
+
+void        I18N_init(const char *lang_code);
+void        I18N_quit(void);
+int         I18N_reload(const char *lang_code);
+char       *I18N_t(const char *key);
+const char *I18N_active_code(void);
+
+#define T(k) I18N_t(k)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lang/en.lang
+++ b/lang/en.lang
@@ -1,0 +1,28 @@
+# minui-presenter — English strings (reference / fallback)
+
+# Default button labels (used when --action/--confirm/--cancel/--inaction-text
+# is not provided on the command line).
+mp.btn.action=ACTION
+mp.btn.select=SELECT
+mp.btn.back=BACK
+mp.btn.other=OTHER
+
+# Pak-provided labels can also be translated if they match these keys.
+# Listed here so the English value (the original literal) is what shows
+# up by default; locale files override only where needed.
+EXIT=EXIT
+QUIT=QUIT
+OK=OK
+OKAY=OKAY
+CANCEL=CANCEL
+BACK=BACK
+RETURN=RETURN
+APPLY=APPLY
+CONFIRM=CONFIRM
+DELETE=DELETE
+YES=YES
+NO=NO
+
+# Common --message strings emitted by paks (Gallery, etc.)
+No screenshots found=No screenshots found
+Screenshots directory not found=Screenshots directory not found

--- a/lang/fr.lang
+++ b/lang/fr.lang
@@ -1,0 +1,29 @@
+# minui-presenter — strings françaises
+
+# Labels par défaut des boutons (utilisés quand --action/--confirm/--cancel/
+# --inaction-text n'est pas fourni en ligne de commande).
+mp.btn.action=ACTION
+mp.btn.select=CHOISIR
+mp.btn.back=RETOUR
+mp.btn.other=AUTRE
+
+# Re-traductions : si un pak passe l'une de ces chaînes anglaises
+# via --cancel-text/--action-text/..., elle est remplacée par le
+# texte ci-dessous. Permet de traduire des paks tiers sans modifier
+# leur launch.sh.
+EXIT=QUITTER
+QUIT=QUITTER
+OK=OK
+OKAY=OK
+CANCEL=ANNULER
+BACK=RETOUR
+RETURN=RETOUR
+APPLY=APPLIQUER
+CONFIRM=CONFIRMER
+DELETE=SUPPRIMER
+YES=OUI
+NO=NON
+
+# Messages --message courants émis par les paks (Gallery, etc.)
+No screenshots found=Aucune capture trouvée
+Screenshots directory not found=Dossier captures introuvable

--- a/minui-presenter.c
+++ b/minui-presenter.c
@@ -20,6 +20,29 @@
 #include "defines.h"
 #include "api.h"
 #include "utils.h"
+#include "i18n/i18n.h"
+
+// Convenience wrapper: read NextUI's persisted language code from
+// minuisettings.txt and bootstrap the i18n table once. Failure is
+// silent — T() falls back to the input string when nothing is loaded.
+static void mp_i18n_init(void)
+{
+    char path[512];
+    snprintf(path, sizeof(path), "%s/.userdata/shared/minuisettings.txt", SDCARD_PATH);
+    FILE *f = fopen(path, "r");
+    char lang[8] = "en";
+    if (f)
+    {
+        char line[128];
+        while (fgets(line, sizeof(line), f))
+        {
+            if (sscanf(line, "language=%7s", lang) == 1)
+                break;
+        }
+        fclose(f);
+    }
+    I18N_init(lang);
+}
 
 // Platform compatibility: tg5050 (NextUI) uses PWR_isOnline instead of PLAT_isOnline
 #ifdef PLATFORM_NEXTUI
@@ -1077,8 +1100,8 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
 
     int opt;
     char *font_path = NULL;
-    char message[1024];
-    char alignment[1024];
+    char message[1024] = "";
+    char alignment[1024] = "";
     while ((opt = getopt_long(argc, argv, "a:A:b:B:c:C:d:D:E:f:F:i:I:K:m:M:t:QPSTUWYXZ", long_options, NULL)) != -1)
     {
         switch (opt)
@@ -1189,7 +1212,7 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
     {
         struct ItemsState *items_state = malloc(sizeof(struct ItemsState));
         items_state->items = malloc(sizeof(struct Item) * 1);
-        items_state->items[0].text = strdup(message);
+        items_state->items[0].text = strdup(T(message));
         items_state->items[0].background_color = "#000000";
         items_state->items[0].background_image = NULL;
         items_state->items[0].image_exists = false;
@@ -1248,9 +1271,14 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
         strncpy(state->action_button, "", sizeof(state->action_button));
     }
 
+    // Default button labels go through T() so they pick up the active
+    // language from NextUI's minuisettings.txt. Caller-provided values
+    // (via --action-text / --cancel-text / ...) are also translated
+    // below via mp_t_into(), so paks passing English strings inherit
+    // localisation for free as long as a matching key exists.
     if (strcmp(state->action_text, "") == 0)
     {
-        strncpy(state->action_text, "ACTION", sizeof(state->action_text));
+        strncpy(state->action_text, T("mp.btn.action"), sizeof(state->action_text));
     }
 
     if (strcmp(state->cancel_button, "") == 0)
@@ -1260,18 +1288,37 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
 
     if (strcmp(state->confirm_text, "") == 0)
     {
-        strncpy(state->confirm_text, "SELECT", sizeof(state->confirm_text));
+        strncpy(state->confirm_text, T("mp.btn.select"), sizeof(state->confirm_text));
     }
 
     if (strcmp(state->cancel_text, "") == 0)
     {
-        strncpy(state->cancel_text, "BACK", sizeof(state->cancel_text));
+        strncpy(state->cancel_text, T("mp.btn.back"), sizeof(state->cancel_text));
     }
 
     if (strcmp(state->inaction_text, "") == 0)
     {
-        strncpy(state->inaction_text, "OTHER", sizeof(state->inaction_text));
+        strncpy(state->inaction_text, T("mp.btn.other"), sizeof(state->inaction_text));
     }
+
+    // After defaults, re-translate any caller-provided text. T() returns
+    // the input unchanged when there is no matching entry, so paks that
+    // already pass localised strings (or arbitrary content like "EXIT")
+    // are unaffected — only known keys are remapped.
+    #define MP_RETRANSLATE(buf) do { \
+        if ((buf)[0] != '\0') { \
+            const char *_v = T(buf); \
+            if (_v != (buf)) { \
+                strncpy((buf), _v, sizeof(buf) - 1); \
+                (buf)[sizeof(buf) - 1] = '\0'; \
+            } \
+        } \
+    } while (0)
+    MP_RETRANSLATE(state->action_text);
+    MP_RETRANSLATE(state->confirm_text);
+    MP_RETRANSLATE(state->cancel_text);
+    MP_RETRANSLATE(state->inaction_text);
+    #undef MP_RETRANSLATE
 
     // validate that hardware buttons aren't assigned to more than once
     bool a_button_assigned = false;
@@ -1528,6 +1575,7 @@ void init()
     PAD_init();
     PWR_init();
     InitSettings();
+
 }
 
 // destruct cleans up the app state in reverse order
@@ -1593,6 +1641,12 @@ int main(int argc, char *argv[])
     strncpy(state.inaction_text, default_inaction_text, sizeof(state.inaction_text));
     strncpy(state.file, default_file, sizeof(state.file));
     strncpy(state.item_key, default_item_key, sizeof(state.item_key));
+
+    // Bootstrap i18n before argv parsing — parse_arguments calls T() on
+    // --message and the button-text args, and the table must be loaded
+    // for those lookups to hit. mp_i18n_init() only reads minuisettings
+    // and the lang files; it does not require SDL/GFX to be up.
+    mp_i18n_init();
 
     // parse the arguments
     if (!parse_arguments(&state, argc, argv))


### PR DESCRIPTION
## Summary

minui-presenter is shared by many third-party MinUI/NextUI paks (Gallery, Artwork Scraper, Another Cheat Downloader, ...) and its button labels are currently hard-coded English. With NextUI now shipping an i18n system (companion PR: https://github.com/LoveRetro/NextUI/pull/735), the presenter can read the same `language=` setting and localise its labels — both the built-in defaults and the strings paks pass via `--action-text` / `--cancel-text` / ...

The result for a French user: launching Gallery now shows **QUITTER** instead of **EXIT** in the bottom-right, without changing any pak's `launch.sh`.

## What it does

- Reads `/mnt/SDCARD/.userdata/shared/minuisettings.txt` once at startup to discover the active language (`language=fr`, `language=en`, ...). Falls back to English if the file or the key is missing.
- Loads the matching `<code>.lang` file from `/mnt/SDCARD/.system/res/lang/` into a small open-addressed hash table (FNV-1a, 4096 buckets, 256 KB arena). Lookups are ~80 ns on a Cortex-A53.
- Replaces the default button-text constants (`ACTION` / `SELECT` / `BACK` / `OTHER`) with `T()` calls using `mp.btn.*` keys.
- **Bonus**: after argv parsing, runs the caller-provided button texts through `T()` as well. So a pak that already passes `--cancel-text "EXIT"` doesn't need to change — as soon as the lang file contains `EXIT=QUITTER`, the bottom-right button reads "QUITTER" on a French system.

## Files

| | Description |
|---|---|
| `include/i18n/i18n.{c,h}` | Pure-C i18n core (same parser, same hash table, same fallback semantics as the NextUI PR). Depends only on `defines.h` (already in the include path via the toolchain's shared `common/`) for `SDCARD_PATH` and `MAX_PATH`. |
| `lang/en.lang`, `lang/fr.lang` | Reference + French. Translators can copy `en.lang` to `<code>.lang` and translate the values; no code change needed. |
| `Makefile` | Adds `include/i18n/i18n.c` to both the macOS and the Linux build SOURCE lines. |
| `minui-presenter.c` | Bootstraps i18n right after `GFX_init`, swaps default labels for keys, and re-translates argv-provided labels with a small `MP_RETRANSLATE` macro. |
| `.gitignore` | Allow `include/i18n/` while keeping the rest of `/include/` ignored (clone targets land there). |

## Compatibility

- **No-op on systems without the lang files**: missing keys fall through to the input literal, so behaviour is identical to today's binary.
- **No-op for already-localised paks**: paks that pass localised strings (no matching key) get no replacement — `T()` returns the input unchanged.
- **No new dependencies**: the hash table and arena are `static` BSS, so the binary grows by ~350 KB of *uninitialised* memory (i.e. not on disk). The file-size delta is just the parser code (~3 KB).

## Test plan

- [x] Cross-compiled for `tg5040` via the upstream `savant/minui-toolchain:tg5040` Docker image (same path as CI)
- [x] Deployed via ADB to a TrimUI Brick running NextUI v6.11.2 with `language=fr` in `minuisettings.txt`
- [x] Gallery pak: bottom-right button now reads "QUITTER" (was "EXIT"); other paks using minui-presenter (Artwork Scraper, Another Cheat Downloader) follow the same behaviour
- [x] Falls back cleanly to English when `language=en` or no lang files present
- [ ] Other toolchains (miyoomini, my282, my355, rg35xxplus, tg5050) — not validated on hardware but the code path is identical

Companion PRs:
- NextUI core i18n + 534 keys: https://github.com/LoveRetro/NextUI/pull/735
- NextUI Updater pak FR: https://github.com/LoveRetro/nextui-updater-pak/pull/18