### PR TITLE
feat: support manual line breaks in messages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,10 +137,29 @@ jobs:
           name: ${{ steps.binary.outputs.filename }}
           path: ${{ steps.binary.outputs.filename }}
 
+  test:
+    name: test
+    runs-on: macos-15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install dependencies
+        run: brew install sdl2 sdl2_image sdl2_ttf pkg-config bats-core
+
+      - name: Build the application
+        run: PLATFORM=macos make
+
+      - name: Set up resources
+        run: PLATFORM=macos make setup-resources
+
+      - name: Run the test suite
+        run: PLATFORM=macos make test
+
   release:
     name: release
     runs-on: ubuntu-24.04-arm
-    needs: [ci, macos]
+    needs: [ci, macos, test]
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,12 @@ endif
 clean:
 	rm -rf $(PRODUCT)-$(PLATFORM)
 
+# Run the integration test suite with bats.
+# Requires a prior `PLATFORM=macos make` and `PLATFORM=macos make setup-resources`.
+.PHONY: test
+test:
+	bats test/
+
 # macOS resource setup - copies MinUI assets to the SDCARD_PATH location
 setup-resources: minui
 ifeq ($(PLATFORM),macos)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ minui-presenter --message "The quick brown fox jumps over the lazy dog"
 - `--background-color <hex-color>`: Default background color to use (default: `#000000`).
 - `--background-image <path>`: Default background image to use (default: empty string).
 - `--message <text>`: Display a single message (default: empty string)
+  - The following backslash escapes are interpreted: `\n` (newline), `\t` (tab), and `\\` (literal backslash). Use `\n` to insert a manual line break, e.g. `--message "line1\nline2"`.
 - `--message-alignment <alignment>`: Set message alignment (default: `middle`)
   - Valid values: `top`, `middle`, `bottom`
 - `--file <path>`: Path to JSON file containing messages (default: empty string)
@@ -69,6 +70,7 @@ minui-presenter --message "The quick brown fox jumps over the lazy dog"
 ### Display Options
 
 - `--disable-auto-sleep`: Disables the auto-sleep functionality (default: `false`)
+- `--disable-auto-wrap`: Disables automatic word wrapping so lines break only at manual newlines (default: `false`). Lines that are wider than the screen are not wrapped and may extend past the screen edge.
 - `--show-hardware-group`: Show hardware information group (default: `false`)
 - `--show-time-left`: Show countdown timer (default: `false`)
 - `--timeout <seconds>`: Set timeout in seconds (default: `0`, no timeout)
@@ -138,7 +140,7 @@ When multiple items are displayed, the list can be scrolled using the `LEFT` AND
 
 ### Item Properties
 
-- `text`: The message to display
+- `text`: The message to display. Text is automatically word-wrapped to fit the screen; a `\n` in the value forces a manual line break (JSON strings use standard JSON escaping). Automatic wrapping can be disabled with `--disable-auto-wrap`.
 - `background_image`: (default: null) Path to background image. Will be stretched to fill screen by aspect ratio. The image will be displayed as soon as it exists.
 - `background_color`: (default: `#000000`) Hex color code for background
 - `show_pill`: (default: `false`) Whether to show a pill around the text

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,4 @@
+# Documentation
+
+- [macOS Build](macos.md) - building and running minui-presenter natively on macOS.
+- [Testing](testing.md) - running the bats integration test suite.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,35 @@
+# Testing
+
+Integration tests are written with [bats](https://github.com/bats-core/bats-core) and live in
+the `test/` directory. They build on the native macOS build and exercise the binary headlessly.
+
+## Prerequisites
+
+```bash
+brew install bats-core
+```
+
+You also need the macOS build prerequisites described in [macos.md](macos.md).
+
+## Running
+
+```bash
+# Build the binary and stage the MinUI resources
+PLATFORM=macos make
+PLATFORM=macos make setup-resources
+
+# Run the test suite
+PLATFORM=macos make test
+```
+
+`make test` runs `bats test/`.
+
+## How the tests work
+
+`minui-presenter` renders to an SDL window, so the tests cannot assert rendered pixels. Instead
+they run the binary with `SDL_VIDEODRIVER=dummy` (no window is opened) and a short `--timeout`,
+then assert that the process exits cleanly on timeout (exit code `124`) rather than crashing.
+This provides a regression guard that message input - including manual newlines from the command
+line and from JSON files - is parsed and rendered without error.
+
+The tests skip automatically if the binary or the MinUI resources are missing.

--- a/minui-presenter.c
+++ b/minui-presenter.c
@@ -154,6 +154,8 @@ struct AppState
     char cancel_text[1024];
     // whether to disable auto sleep
     bool disable_auto_sleep;
+    // whether to disable automatic word wrapping (only break on newlines)
+    bool disable_auto_wrap;
     // the button to display on the Inaction button
     char inaction_button[1024];
     // whether to show the Inaction button
@@ -210,6 +212,44 @@ void strtrim(char *s)
     }
 
     memmove(s, p, l + 1);
+}
+
+// unescape_string interprets backslash escape sequences in place.
+// Supported escapes: "\n" (newline), "\t" (tab), and "\\" (literal backslash).
+// Any other escape sequence is left untouched (both the backslash and the
+// following character are preserved). This is applied to the --message flag so
+// that callers can insert manual line breaks from the command line.
+void unescape_string(char *str)
+{
+    char *src = str;
+    char *dst = str;
+    while (*src != '\0')
+    {
+        if (*src == '\\' && *(src + 1) != '\0')
+        {
+            switch (*(src + 1))
+            {
+            case 'n':
+                *dst++ = '\n';
+                src += 2;
+                continue;
+            case 't':
+                *dst++ = '\t';
+                src += 2;
+                continue;
+            case '\\':
+                *dst++ = '\\';
+                src += 2;
+                continue;
+            default:
+                // unknown escape: keep the backslash and let the next
+                // character be copied on the following iteration
+                break;
+            }
+        }
+        *dst++ = *src++;
+    }
+    *dst = '\0';
 }
 
 char *read_stdin()
@@ -813,26 +853,53 @@ void draw_screen(SDL_Surface *screen, struct AppState *state)
     int message_padding = SCALE1(PADDING + BUTTON_PADDING);
 
     // get the width and height of every word in the message
+    // words are separated by whitespace; an embedded newline forces a line
+    // break. breaks_before[i] records how many newlines precede words[i] so
+    // that consecutive newlines can render as blank lines.
     struct Message words[1024];
+    int breaks_before[1024];
     int word_count = 0;
     char original_message[1024];
     strncpy(original_message, state->items_state->items[state->items_state->selected].text, sizeof(original_message));
-    char *word = strtok(original_message, " ");
+    original_message[sizeof(original_message) - 1] = '\0';
     int word_height = 0;
-    while (word != NULL)
+    int pending_breaks = 0;
+    char *cursor = original_message;
+    while (*cursor != '\0' && word_count < 1024)
     {
-        int word_width;
-        strtrim(word);
-        if (strcmp(word, "") == 0)
+        // newlines force a line break; other whitespace only separates words
+        if (*cursor == '\n')
         {
+            pending_breaks++;
+            cursor++;
+            continue;
+        }
+        if (*cursor == ' ' || *cursor == '\t' || *cursor == '\r')
+        {
+            cursor++;
             continue;
         }
 
-        TTF_SizeUTF8(state->fonts.large, word, &word_width, &word_height);
-        strncpy(words[word_count].message, word, sizeof(words[word_count].message));
+        char *word_start = cursor;
+        while (*cursor != '\0' && *cursor != ' ' && *cursor != '\t' && *cursor != '\r' && *cursor != '\n')
+        {
+            cursor++;
+        }
+
+        int word_length = cursor - word_start;
+        if (word_length >= (int)sizeof(words[word_count].message))
+        {
+            word_length = sizeof(words[word_count].message) - 1;
+        }
+        memcpy(words[word_count].message, word_start, word_length);
+        words[word_count].message[word_length] = '\0';
+
+        int word_width;
+        TTF_SizeUTF8(state->fonts.large, words[word_count].message, &word_width, &word_height);
         words[word_count].width = word_width;
+        breaks_before[word_count] = pending_breaks;
+        pending_breaks = 0;
         word_count++;
-        word = strtok(NULL, " ");
     }
 
     int letter_width = 0;
@@ -852,13 +919,21 @@ void draw_screen(SDL_Surface *screen, struct AppState *state)
     int current_message_index = 0;
     for (int i = 0; i < word_count; i++)
     {
+        // apply any forced line breaks (from newlines) that precede this word;
+        // consecutive newlines leave blank lines between the words
+        for (int b = 0; b < breaks_before[i] && current_message_index < MAIN_ROW_COUNT - 1; b++)
+        {
+            current_message_index++;
+            message_count++;
+        }
+
         if (current_message_index >= MAIN_ROW_COUNT)
         {
             break;
         }
 
         int potential_width = messages[current_message_index].width + words[i].width;
-        if (i > 0)
+        if (messages[current_message_index].width != 0)
         {
             potential_width += letter_width;
         }
@@ -868,25 +943,23 @@ void draw_screen(SDL_Surface *screen, struct AppState *state)
             strncpy(messages[current_message_index].message, words[i].message, sizeof(messages[current_message_index].message));
             messages[current_message_index].width = words[i].width;
         }
-        else if (potential_width <= FIXED_WIDTH - 2 * message_padding)
+        else if (state->disable_auto_wrap || potential_width <= FIXED_WIDTH - 2 * message_padding)
         {
-            if (messages[current_message_index].width == 0)
-            {
-                strncpy(messages[current_message_index].message, words[i].message, sizeof(messages[current_message_index].message));
-            }
-            else
-            {
-                char messageBuf[256];
-                snprintf(messageBuf, sizeof(messageBuf), "%s %s", messages[current_message_index].message, words[i].message);
-
-                strncpy(messages[current_message_index].message, messageBuf, sizeof(messages[current_message_index].message));
-            }
+            // append to the current line either because it still fits or
+            // because automatic wrapping is disabled (break only on newlines)
+            char messageBuf[1024];
+            snprintf(messageBuf, sizeof(messageBuf), "%s %s", messages[current_message_index].message, words[i].message);
+            strncpy(messages[current_message_index].message, messageBuf, sizeof(messages[current_message_index].message));
             messages[current_message_index].width += words[i].width;
         }
         else
         {
             current_message_index++;
             message_count++;
+            if (current_message_index >= MAIN_ROW_COUNT)
+            {
+                break;
+            }
             strncpy(messages[current_message_index].message, words[i].message, sizeof(messages[current_message_index].message));
             messages[current_message_index].width = words[i].width;
         }
@@ -907,15 +980,18 @@ void draw_screen(SDL_Surface *screen, struct AppState *state)
     for (int i = 0; i <= message_count; i++)
     {
         char *message = messages[i].message;
-        if (message == NULL)
+
+        // blank lines (produced by consecutive newlines) still occupy a row
+        if (message[0] == '\0')
         {
+            current_message_y += word_height + SCALE1(PADDING);
             continue;
         }
 
-        int width = messages[i].width;
         SDL_Surface *text = TTF_RenderUTF8_Blended(state->fonts.large, message, COLOR_WHITE);
         if (text == NULL)
         {
+            current_message_y += word_height + SCALE1(PADDING);
             continue;
         }
 
@@ -936,6 +1012,7 @@ void draw_screen(SDL_Surface *screen, struct AppState *state)
         }
 
         SDL_BlitSurface(text, NULL, screen, &pos);
+        SDL_FreeSurface(text);
         current_message_y += word_height + SCALE1(PADDING);
     }
     if (state->action_show && strcmp(state->action_button, "") != 0)
@@ -1030,6 +1107,7 @@ void signal_handler(int signal)
 // - --cancel-text <text> (default: "BACK")
 // - --cancel-show (default: false)
 // - --disable-auto-sleep (default: false)
+// - --disable-auto-wrap (default: false)
 // - --inaction-button <button> (default: empty string)
 // - --inaction-text <text> (default: "OTHER")
 // - --inaction-show (default: false)
@@ -1037,8 +1115,8 @@ void signal_handler(int signal)
 // - --item-key <key> (default: "items")
 // - --message <message> (default: empty string)
 // - --message-alignment <alignment> (default: middle)
-// - --font <path> (default: empty string)
-// - --font-size <size> (default: FONT_LARGE)
+// - --font-default <path> (default: empty string)
+// - --font-size-default <size> (default: FONT_LARGE)
 // - --quit-after-last-item (default: false)
 // - --show-hardware-group (default: false)
 // - --show-pill (default: false)
@@ -1069,6 +1147,7 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
         {"show-time-left", no_argument, 0, 'T'},
         {"timeout", required_argument, 0, 't'},
         {"disable-auto-sleep", no_argument, 0, 'U'},
+        {"disable-auto-wrap", no_argument, 0, 'w'},
         {"confirm-show", no_argument, 0, 'W'},
         {"cancel-show", no_argument, 0, 'X'},
         {"action-show", no_argument, 0, 'Y'},
@@ -1077,9 +1156,9 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
 
     int opt;
     char *font_path = NULL;
-    char message[1024];
-    char alignment[1024];
-    while ((opt = getopt_long(argc, argv, "a:A:b:B:c:C:d:D:E:f:F:i:I:K:m:M:t:QPSTUWYXZ", long_options, NULL)) != -1)
+    char message[1024] = "";
+    char alignment[1024] = "";
+    while ((opt = getopt_long(argc, argv, "a:A:b:B:c:C:d:D:E:f:F:i:I:K:m:M:t:QPSTUWYXZw", long_options, NULL)) != -1)
     {
         switch (opt)
         {
@@ -1149,6 +1228,9 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
         case 'U':
             state->disable_auto_sleep = true;
             break;
+        case 'w':
+            state->disable_auto_wrap = true;
+            break;
         case 'W':
             state->confirm_show = true;
             break;
@@ -1165,6 +1247,11 @@ bool parse_arguments(struct AppState *state, int argc, char *argv[])
             return false;
         }
     }
+
+    // interpret backslash escapes (e.g. "\n") supplied via --message so that
+    // line breaks can be provided from the command line. JSON input handles its
+    // own escaping and is intentionally left untouched.
+    unescape_string(message);
 
     enum MessageAlignment default_alignment = MessageAlignmentMiddle;
     if (strcmp(alignment, "top") == 0)
@@ -1572,6 +1659,7 @@ int main(int argc, char *argv[])
         .confirm_show = false,
         .cancel_show = false,
         .disable_auto_sleep = false,
+        .disable_auto_wrap = false,
         .inaction_show = false,
         .quit_after_last_item = false,
         .show_time_left = false,

--- a/test/fixtures/newline.json
+++ b/test/fixtures/newline.json
@@ -1,0 +1,8 @@
+{
+  "items": [
+    {
+      "text": "first line\nsecond line",
+      "background_color": "#000000"
+    }
+  ]
+}

--- a/test/newline.bats
+++ b/test/newline.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+#
+# Integration tests for manual newline (\n) support in messages.
+#
+# minui-presenter renders to an SDL window, so these tests cannot assert
+# rendered pixels. Instead they run the binary headless (SDL_VIDEODRIVER=dummy)
+# with a short timeout and assert that newline input - from both the CLI and a
+# JSON file - is accepted and the program exits cleanly on timeout (exit code
+# 124, per the documented exit codes) rather than crashing.
+
+setup() {
+    BIN="${MINUI_PRESENTER_BIN:-./minui-presenter-macos}"
+    FIXTURES="${BATS_TEST_DIRNAME}/fixtures"
+
+    # exit code returned when --timeout is reached
+    TIMEOUT_EXIT=124
+
+    if [ ! -x "$BIN" ]; then
+        skip "binary not found at $BIN (run: PLATFORM=macos make)"
+    fi
+    if [ ! -f /tmp/FAKESD/.system/res/BPreplayBold-unhinted.otf ]; then
+        skip "resources missing (run: PLATFORM=macos make setup-resources)"
+    fi
+
+    export SDL_VIDEODRIVER=dummy
+    export SDL_AUDIODRIVER=dummy
+}
+
+@test "renders a message containing a real newline" {
+    run "$BIN" --message $'first line\nsecond line' --timeout 1
+    [ "$status" -eq "$TIMEOUT_EXIT" ]
+}
+
+@test "interprets a literal backslash-n as a newline" {
+    run "$BIN" --message 'first line\nsecond line' --timeout 1
+    [ "$status" -eq "$TIMEOUT_EXIT" ]
+}
+
+@test "interprets literal backslash-t and escaped backslash" {
+    run "$BIN" --message 'a\tb\\nc' --timeout 1
+    [ "$status" -eq "$TIMEOUT_EXIT" ]
+}
+
+@test "renders consecutive newlines as a blank line" {
+    run "$BIN" --message $'first\n\nthird' --timeout 1
+    [ "$status" -eq "$TIMEOUT_EXIT" ]
+}
+
+@test "renders newlines with automatic wrapping disabled" {
+    run "$BIN" --disable-auto-wrap \
+        --message $'a very long line that would normally wrap across the screen\nsecond' \
+        --timeout 1
+    [ "$status" -eq "$TIMEOUT_EXIT" ]
+}
+
+@test "renders a newline supplied via a JSON file" {
+    run "$BIN" --file "${FIXTURES}/newline.json" --timeout 1
+    [ "$status" -eq "$TIMEOUT_EXIT" ]
+}
+
+@test "still renders a plain message without newlines" {
+    run "$BIN" --message 'a plain message without any newlines' --timeout 1
+    [ "$status" -eq "$TIMEOUT_EXIT" ]
+}


### PR DESCRIPTION
Messages previously supported only automatic word wrapping, with no way to force a line break where the caller wanted one. The `--message` flag now interprets `\n`, `\t`, and `\\` escapes, so a manual line break can be provided from the command line, for example `--message "line1\nline2"`. Newlines are rendered as manual line breaks in both command-line messages and JSON `--file` messages, and automatic word wrapping still applies within each line so long segments continue to wrap to fit the screen.

For callers that want full control over where lines break, a new `--disable-auto-wrap` flag turns off automatic wrapping so that lines break only at manual newlines.

This also corrects the stale `--font` and `--font-size` argument comments to `--font-default` and `--font-size-default`.

Closes #37.